### PR TITLE
Update DefaultStakerRewards address

### DIFF
--- a/vaults/0xf56179944d867469612d138c74f1de979d3fac72/info.json
+++ b/vaults/0xf56179944d867469612d138c74f1de979d3fac72/info.json
@@ -21,7 +21,7 @@
   ],
   "rewards": [
     {
-      "address": "0xe0bf535F776d900D499407623C03bACe81334127",
+      "address": "0xa4431fA6a4cF16CA0381F6f294973D58f0aa3510",
       "type": "defaultStakingRewardsV2"
     }
   ]


### PR DESCRIPTION
Use `DefaultStakerRewards` deployed using new factory at https://sepolia.etherscan.io/address/0xE6381EDA7444672da17Cd859e442aFFcE7e170F0